### PR TITLE
fix: PFS_PREC variable is no longer saved when config.overwinter is f…

### DIFF
--- a/ncfwi/readwrite.py
+++ b/ncfwi/readwrite.py
@@ -165,7 +165,9 @@ def combine_batched_files(year: int, drop_vars: list[str] | None = None) -> None
     config = get_config()
     path_out = config["settings"]["output_dir"]
     output_vars = config["settings"]["output_vars"]
-    output_vars = np.append(output_vars, ["PFS_PREC"])
+    overwinter = config["settings"]["overwinter"]
+    if overwinter and "PFS_PREC" not in output_vars:
+        output_vars = np.append(output_vars, ["PFS_PREC"])
 
     for var_name in output_vars:
         var_path = os.path.join(path_out, str(var_name))


### PR DESCRIPTION
Previously, the variable PFS_PREC (post-fire season precipitation) was saved even when overwinter was set to false. This was a problem because the variable is only calculated when overwinter is true.

Now, PFS_PREC variable is no longer saved when config.overwinter is false.